### PR TITLE
Balance command update

### DIFF
--- a/bin/dropzone
+++ b/bin/dropzone
@@ -74,7 +74,7 @@ command 'balance' do |c|
 
   c.syntax, c.summary, c.description = 
     'dropzone balance <addr>',
-    'Display the balance on the provided address, in Bitcoin',
+    'Display the balance on the provided address, in Bitcoin, not including unconfirmed txs',
     multi(<<-eos)
       Given the provided public key, display the Bitcoin balance remaining in
       this account. Does not include unconfirmed transactions.


### PR DESCRIPTION
Pedantic but important, users shouldn’t have to dig to find out that
the balance doesn’t include unconfirmed txs. Closes
17Q4MX2hmktmpuUKHFuoRmS5MfB5XPbhod/dropzone_ruby/#4
